### PR TITLE
some code refactor, terminal & layout changes

### DIFF
--- a/cursewords/chars.py
+++ b/cursewords/chars.py
@@ -18,3 +18,8 @@ lhblock = "▌"
 rhblock = "▐"
 fullblock = "█"
 squareblock = rhblock + fullblock + lhblock
+
+smallify_numbers = str.maketrans('0123456789', '₀₁₂₃₄₅₆₇₈₉')
+encircle_letters = str.maketrans('ABCDEFGHIJKLMNOPQRSTUVWXYZ ',
+                                 'ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ◯')
+

--- a/cursewords/cursewords.py
+++ b/cursewords/cursewords.py
@@ -836,7 +836,7 @@ def main():
             if not puzzle_complete and all(grid.cells.get(pos).is_correct()
                     for pos in grid.cells):
                 puzzle_complete = True
-                with term.location(x=grid_x, y=2):
+                with term.location(**info_location):
                     echo(term.reverse("You've completed the puzzle!") + term.clear_eol)
                 timer.show_time()
                 timer.active = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-blessed==1.15.0
+blessed>=1.17.12,<2
 puzpy==0.2.4


### PR DESCRIPTION
- properly setup backspace vs. delete (requires upgrade of blessed library)
- use "bright_black" instead of "dim", dim has less compatibility (didn't work on whatever terminal I was using at the time)
- create functional alias for print as "echo", which does not print a newline
- center the crosswords puzzle horizontally on the screen
- move "you win" message, it was occluding / printing over the puzzle

I wanted to make it easier to use a smaller terminal dimension, I think if we put the puzzle on the left or right side of the screen with some padding, there should be plenty of room for the information, hints, etc on the other side of the screen (using textwrap library if necessary), reducing the vertical requirement even further, the more the vertical height can be reduced, the larger the fontsize can be! I was also hoping to make it so you could resize the window during runtime. Anyway, this was what I was doing while looking for a job, found a job, now i'm busy, that's how it goes!