### PR TITLE
cursewords: improve clue formatting and alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 pip3 install cursewords
 ```
 
-You should then be ready to go. You can then use  `cursewords` to open `.puz` files directly:
+You should then be ready to go. You can then use `cursewords` to open `.puz` files directly:
 
 ```
 cursewords todaysnyt.puz
@@ -36,6 +36,6 @@ To open a puzzle in `downs-only` mode, where only the down clues are visible, us
 
 If `cursewords` is not running in an interactive terminal (because its output is being piped to another command or redirected to a file) or if you pass the `--print` flag directly, it will print a formatted grid and list of clues to stdout and quit. The output of that command can be modified with the following flags:
 
-* `--blank` ensures the grid is unfilled, even if you've saved solving progress
-* `--solution` prints the filled grid
-* `--width INT` caps the program output at INT characters wide. (If this flag isn't passed at runtime, `cursewords` will attempt to pick a reasonable output size. In many cases that will be 92 characters or the width of the puzzle.)
+- `--blank` ensures the grid is unfilled, even if you've saved solving progress
+- `--solution` prints the filled grid
+- `--width INT` caps the program output at INT characters wide. (If this flag isn't passed at runtime, `cursewords` will attempt to pick a reasonable output size. In many cases that will be 92 characters or the width of the puzzle.)

--- a/cursewords/printer.py
+++ b/cursewords/printer.py
@@ -6,17 +6,29 @@ def printer_output(grid, style=None, width=None, downs_only=False):
     print_width = width or (92 if not sys.stdout.isatty()
                             else min(grid.term.width, 96))
 
+    # Create clue lists but now we'll store number and clue separately
     clue_lines = ['ACROSS', '']
-    clue_lines.extend(['. '.join([str(entry['num']), entry['clue'].strip()])
-                       for entry in grid.clues['across']])
+    across_clues = [(entry['num'], entry['clue'].strip()) for entry in grid.clues['across']]
+    down_clues = [(entry['num'], entry['clue'].strip()) for entry in grid.clues['down']]
+    
+    # Find the maximum width needed for number alignment
+    max_num_width = 0
+    for num, _ in across_clues + down_clues:
+        max_num_width = max(max_num_width, len(str(num)))
+    
+    # Format across clues with aligned numbers
+    for num, clue in across_clues:
+        clue_lines.append(f"{num:>{max_num_width}}. {clue}")
     clue_lines.append('')
 
     if downs_only:
         clue_lines = []
-
+        # Still need to keep max_num_width for downs
+    
     clue_lines.extend(['DOWN', ''])
-    clue_lines.extend(['. '.join([str(entry['num']), entry['clue'].strip()])
-                       for entry in grid.clues['down']])
+    # Format down clues with aligned numbers
+    for num, clue in down_clues:
+        clue_lines.append(f"{num:>{max_num_width}}. {clue}")
 
     render_args = {'blank': style == 'blank', 'solution': style == 'solution'}
 
@@ -40,7 +52,9 @@ def printer_output(grid, style=None, width=None, downs_only=False):
     if f_width > 12:
         while grid_lines:
             current_clue = (current_clue or
-                            textwrap.wrap(clue_lines.pop(0), f_width) or
+                            textwrap.wrap(clue_lines.pop(0), f_width,
+                                        initial_indent="",
+                                        subsequent_indent=" " * (max_num_width + 2)) or
                             [''])
             current_line = current_clue.pop(0)
             current_grid_line = grid_lines.pop(0)
@@ -55,11 +69,41 @@ def printer_output(grid, style=None, width=None, downs_only=False):
     wrapped_clue_lines = []
     num_cols = 3 if print_width > 64 else 2
     column_width = print_width // num_cols - 2
+    
     for l in clue_lines:
         if len(l) < column_width:
             wrapped_clue_lines.append(l)
         else:
-            wrapped_clue_lines.extend(textwrap.wrap(l, width=column_width))
+            # For header rows like "ACROSS" and "DOWN" or empty lines
+            if l in ["ACROSS", "DOWN", ""]:
+                wrapped_clue_lines.append(l)
+                continue
+            
+            # For clue lines, which now have aligned numbers in format "NN. clue text"
+            # The period is already at a fixed position based on max_num_width
+            parts = l.split('. ', 1)
+            if len(parts) == 2:
+                num_part = parts[0]
+                clue_text = parts[1]
+                
+                # Calculate the indent width for continuation lines
+                # This includes the right-aligned number plus ". "
+                indent_width = max_num_width + 2
+                
+                # Wrap the text with proper indentation for continuation lines
+                wrapper = textwrap.TextWrapper(
+                    width=column_width,
+                    initial_indent="",
+                    subsequent_indent=" " * indent_width
+                )
+                
+                # Format the clue with the already aligned number and wrap the text
+                formatted_clue = f"{num_part}. {clue_text}"
+                lines = wrapper.wrap(formatted_clue)
+                wrapped_clue_lines.extend(lines)
+            else:
+                # Fallback for any other lines
+                wrapped_clue_lines.extend(textwrap.wrap(l, width=column_width))
 
     num_wrapped_rows = math.ceil(len(wrapped_clue_lines)/num_cols)
 


### PR DESCRIPTION
Enhance output readability by aligning clue numbers and adding proper
indentation for wrapped clues. Numbers are now right-aligned with
consistent spacing, and wrapped lines are indented to align with the
start of the clue text. Also improves handling of column layout for
better visual organization of clues.

Fixes #44 
